### PR TITLE
Replace deprecated function GetVersion() with GetOsVersion()

### DIFF
--- a/collectorCore/collectorCore.brs
+++ b/collectorCore/collectorCore.brs
@@ -104,12 +104,12 @@ function getVersion(param = invalid)
 end function
 
 function getUserAgent(param = invalid)
-    osVersion=m.deviceInfo.GetOsVersion()
-    versionMajor=osVersion.major
-    versionMinor=osVersion.minor
-    versionBuild=substitute("{0}{1}",osVersion.revision, osVersion.build)
+  osVersion=m.deviceInfo.GetOsVersion()
+  versionMajor=osVersion.major
+  versionMinor=osVersion.minor
+  versionBuild=substitute("{0}{1}",osVersion.revision, osVersion.build)
 
-    return substitute("Roku/DVP-{0}.{1} ({2})", versionMajor, versionMinor, versionBuild)
+  return substitute("Roku/DVP-{0}.{1} ({2})", versionMajor, versionMinor, versionBuild)
 end function
 
 function getDeviceInformation(param = invalid)

--- a/collectorCore/collectorCore.brs
+++ b/collectorCore/collectorCore.brs
@@ -105,11 +105,9 @@ end function
 
 function getUserAgent(param = invalid)
   osVersion=m.deviceInfo.GetOsVersion()
-  versionMajor=osVersion.major
-  versionMinor=osVersion.minor
   versionBuild=substitute("{0}{1}",osVersion.revision, osVersion.build)
 
-  return substitute("Roku/DVP-{0}.{1} ({2})", versionMajor, versionMinor, versionBuild)
+  return substitute("Roku/DVP-{0}.{1} ({2})", osVersion.major, osVersion.minor, versionBuild)
 end function
 
 function getDeviceInformation(param = invalid)

--- a/collectorCore/collectorCore.brs
+++ b/collectorCore/collectorCore.brs
@@ -104,15 +104,12 @@ function getVersion(param = invalid)
 end function
 
 function getUserAgent(param = invalid)
-  version=m.deviceInfo.GetVersion()
-  versionMajor=mid(version,3,1)
-  versionMinor=mid(version,5,2)
-  versionBuild=mid(version,8,5)
+    osVersion=m.deviceInfo.GetOsVersion()
+    versionMajor=osVersion.major
+    versionMinor=osVersion.minor
+    versionBuild=substitute("{0}{1}",osVersion.revision, osVersion.build)
 
-  if versionMinor.toint() < 10 then
-      versionMinor=mid(versionMinor,2)
-  end if
-  return "Roku/DVP-"+versionMajor+"."+versionMinor+" ("+version+")"
+    return substitute("Roku/DVP-{0}.{1} ({2})", versionMajor, versionMinor, versionBuild)
 end function
 
 function getDeviceInformation(param = invalid)


### PR DESCRIPTION
## Description
Update deprecate function used on deviceInfo.

## Problem
Roku analysis throws a warning on code.  (img)
![image](https://user-images.githubusercontent.com/49044962/114706340-7f527200-9d31-11eb-9e13-4ff08068e805.png)

## Fix
Replaced deprecated function with the usable one. 

## Checklist (for PR submitters and reviewers)

- [ ] `CHANGELOG` entry
- [ ] Tests
  - [ ] Test(s) within the PR, and/or
  - [ ] Link(s) to existing test class(es) that cover the PR, and/or
  - [ ] Coherent argumentation why the PR cannot be covered by tests
