### PR TITLE
fix crash with extra invalid check on parent

### DIFF
--- a/collectorCore/analyticsDataTask.brs
+++ b/collectorCore/analyticsDataTask.brs
@@ -42,7 +42,7 @@ sub execute()
 
     if m.top.playerState = "playing" and m.heartbeatTimer.totalMilliseconds() > 59*1000
       parent = m.top.getParent()
-      if parent.fireHeartbeat <> invalid
+      if parent <> invalid and parent.fireHeartbeat <> invalid
         parent.fireHeartbeat = true
         m.heartbeatTimer.Mark()
       end if


### PR DESCRIPTION
## Description
Sometimes when backing out of the player while the "ads are loading" message displays causes the app to crash

## Problem
`parent` was invalid and the code tries to access `parent.fireHeartbeat`

## Fix
Add extra check for `parent <> invalid`

## Tests
N/A as this bug was found in an app currently in development. The issue had low reproducibility rates.

## Checklist (for PR submitters and reviewers)

- [ ] `CHANGELOG` entry
- [ ] Tests
  - [ ] Test(s) within the PR, and/or
  - [ ] Link(s) to existing test class(es) that cover the PR, and/or
  - [X] Coherent argumentation why the PR cannot be covered by tests

No `CHANGELOG` entry since this is a minor change.
