### PR TITLE
Fix console warnings for unused variables

### DIFF
--- a/collectorCore/collectorCore.brs
+++ b/collectorCore/collectorCore.brs
@@ -100,17 +100,17 @@ sub clearSampleValues()
   m.sample.errorMessage = invalid
 end sub
 
-function getVersion(param = invalid)
+function getVersion()
   return m.version
 end function
 
-function getUserAgent(param = invalid)
+function getUserAgent()
   osVersion = m.deviceInfo.GetOSVersion()
   versionBuild = substitute("{0}{1}", osVersion.revision, osVersion.build)
   return substitute("Roku/DVP-{0}.{1} ({2})", osVersion.major, osVersion.minor, versionBuild)
 end function
 
-function getDeviceInformation(param = invalid)
+function getDeviceInformation()
  return {
     manufacturer: m.deviceInfo.GetModelDetails().VendorName,
     model: m.deviceInfo.GetModel(),
@@ -118,11 +118,11 @@ function getDeviceInformation(param = invalid)
  }
 end function
 
-function createImpressionId(param = invalid)
+function createImpressionId()
   return lcase(m.deviceInfo.GetRandomUUID())
 end function
 
-function getCurrentImpressionId(param = invalid)
+function getCurrentImpressionId()
   return m.sample.impressionId
 end function
 


### PR DESCRIPTION
## Description
This pull request will remove the variables that are unused inside of some functions around the collectorCore

## Problem
After Roku OS 11.0, the console will show how many variables are unused inside the application.
![image](https://user-images.githubusercontent.com/49044962/170052478-84d3f8df-9469-46c0-8082-38ab3a5cb27e.png)


## Fix
Remove the unused variables.

## Tests
<!-- Reference unit tests and/or player tests or explain why testing is not possible/applicable. See checklist below for details. -->

## Checklist (for PR submitters and reviewers)

- [ ] `CHANGELOG` entry
- [ ] Tests
  - [ ] Test(s) within the PR, and/or
  - [ ] Link(s) to existing test class(es) that cover the PR, and/or
  - [ ] Coherent argumentation why the PR cannot be covered by tests

<!-- For every PR that gets merged although it violates the checklist, the PR submitter and all reviewers buy a round of drinks for the whole player team! -->
